### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,8 @@ impl FromStr for CaseMode {
 
             _ => Err(format_err!(
                 "Unknown case mode '{}'. Expected one of \
-                 'auto', 'sensitive', or 'insensitive'."
+                 'auto', 'sensitive', or 'insensitive'.",
+                input,
             )),
         }
     }


### PR DESCRIPTION
Without this, the error message would literally be "Unknown case mode '{}'. Expected one of 'auto', 'sensitive', or 'insensitive'" with curly braces in it instead of the unknown input.